### PR TITLE
requirement.txt file for easier installation (and a .gitignore for easier commit)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,102 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+.hypothesis/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# pyenv
+.python-version
+
+# celery beat schedule file
+celerybeat-schedule
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+
+# config files
+*.cfg

--- a/linux/requirements.txt
+++ b/linux/requirements.txt
@@ -1,0 +1,10 @@
+arabic-reshaper==2.0.8
+beautifulsoup4==4.6.0
+bs4==0.0.1
+certifi==2017.7.27.1
+chardet==3.0.4
+configparser==3.5.0
+future==0.16.0
+idna==2.6
+requests==2.18.4
+urllib3==1.22


### PR DESCRIPTION
with a requirements.txt file installation would be as easy as first installing
- python3
- tk

and then running:
```bash
  $ pip3 install -g -r requirements.txt
```

Of course for a cleaner and more reliable installation one could first create a virtual environment:
```bash
$ cd linux
$ python3 -m venv .venv
```
activate it:
```bash
$ . ./.venv/bin/activate
```
and then install the requirements and run the program:
```bash
$ pip install -r requirements.txt
$ python open_source.py
```
the virtual environment can be easily deactivated using:
```bash
$ deactivate
```

I'd like to suggest adding the latter method of installation and execution to the `README` file because of its higher reliability. As the package versions are fixed in the requirements.txt file, package updates won't accidentally break the program.